### PR TITLE
fix-bug-on-run-main-button

### DIFF
--- a/app_runner.py
+++ b/app_runner.py
@@ -349,15 +349,15 @@ class App(QMainWindow):
         優先度0のPythonファイルを一括実行する
         """
         main_items = []
-        for item in self.file_tree.get_children():
-            values = self.file_tree.item(item)['values']
-            if values[0] == 0:  # 優先度が0のアイテムを選択
+        # すべてのトップレベルアイテムを取得
+        for i in range(self.file_tree.topLevelItemCount()):
+            item = self.file_tree.topLevelItem(i)
+            if item.text(0) == "0":  # 優先度が0のアイテムを選択
                 main_items.append(item)
         
         if main_items:
             for item in main_items:
-                values = self.file_tree.item(item)['values']
-                file_path = values[3]  # 絶対パスは4番目の列
+                file_path = item.text(3)  # 絶対パスは4列目
                 try:
                     threading.Thread(target=execute_script, args=(file_path,), daemon=True).start()
                     time.sleep(0.1)


### PR DESCRIPTION
# 🐛 tkinter から PySide6 への移行に伴うメソッド修正

## 修正内容
- `run_main_files`メソッドのツリーウィジェット操作を修正
- tkinter固有のメソッドをPySide6のメソッドに置換

## 技術的な変更点
1. **メソッドの置換**
   - `get_children()` → `topLevelItemCount()` と `topLevelItem(i)`
   - アイテムの値取得方法を`item['values']`から`item.text(column)`に変更

2. **ロジックの調整**
   - トップレベルアイテムの列挙方法を変更
   - 優先度0のアイテム抽出ロジックを維持

## 影響範囲
- `run_main_files`メソッドのみの修正
- 他の機能への影響なし

## 動作確認項目
- [x] 優先度0のファイルの抽出
- [x] 一括実行機能の動作
- [x] エラーハンドリング

## バグの原因
tkinterからPySide6への移行時に、ツリーウィジェットの操作メソッドの違いを考慮していなかったため

## 修正の利点
- PySide6の標準的なAPIを使用
- より安定した動作を実現
- コードの一貫性を向上