### PR TITLE
macOS開発/起動対応とOS別起動処理の改善

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,19 @@
 *.csv
 *.db
 *.yaml
+
+# セキュリティ/ローカル環境向け: 認証情報や個人環境依存ファイルを除外
+.env
+.env.*
+*.pem
+*.key
+*.p12
+
+# Python仮想環境・キャッシュ
+.venv/
+venv/
+__pycache__/
+*.pyc
+
+# macOSのメタデータ
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -23,17 +23,31 @@
 - ウィンドウ位置保存: CSV
 
 ## 使用方法
-1. アプリケーションの起動
-   - 以下のような内容でショートカットファイルを作成します：
-     ```
-     %windir%\System32\cmd.exe "/C" C:\ProgramData\Anaconda3\Scripts\activate.bat base && D: && cd D:\Tools\PythonRunner && python D:\Tools\PythonRunner\app_runner.py
-     ```
-   - このショートカットファイルをダブルクリックして起動します
-   - ショートカットの内容説明：
-     - Anaconda環境をアクティベート
-     - 作業ドライブに移動
-     - 作業ディレクトリに移動
-     - Pythonスクリプトを実行
+1. アプリケーションの起動（Windows / macOS 対応）
+   - **Windows（従来運用）**
+     - 以下のような内容でショートカットファイルを作成します：
+       ```
+       %windir%\System32\cmd.exe "/C" C:\ProgramData\Anaconda3\Scripts\activate.bat base && D: && cd D:\Tools\PythonRunner && python D:\Tools\PythonRunner\app_runner.py
+       ```
+     - このショートカットファイルをダブルクリックして起動します
+     - ショートカットの内容説明：
+       - Anaconda環境をアクティベート
+       - 作業ドライブに移動
+       - 作業ディレクトリに移動
+       - Pythonスクリプトを実行
+   - **macOS（追加対応）**
+     - 任意の仮想環境を作成し、依存をインストールします。
+       ```bash
+       python3 -m venv .venv
+       source .venv/bin/activate
+       pip install PySide6 pyyaml
+       ```
+     - その後、次のコマンドで起動します。
+       ```bash
+       python3 app_runner.py
+       ```
+     - VSCode連携を使う場合は、VSCodeのコマンドパレットから  
+       **Shell Command: Install 'code' command in PATH** を実行してください。
 
 2. フォルダの選択
    - 「選択」ボタンでフォルダを選択する
@@ -119,6 +133,8 @@
 - Pythonの実行環境が必要です（Anaconda環境推奨）
 - 適切なショートカット設定が必要です
 - ショートカットのパスは実際の環境に合わせて変更してください
+- macOS/Linux では「フォルダを開く」はOS標準のコマンド（`open` / `xdg-open`）を使います
+- macOS/Linux で「VSCodeで開く」を使うには `code` コマンドをPATHに通す必要があります
 - フォルダの書き込み権限が必要です
 - VSCode連携にはVSCodeのインストールが必要です
 - ウィンドウ位置の保存にはCSVファイルの書き込み権限が必要です

--- a/app_runner.py
+++ b/app_runner.py
@@ -202,8 +202,8 @@ def open_folder_in_vscode(folder_path):
         raise FileNotFoundError(f"フォルダが見つかりません: {normalized_path}")
 
     # なぜこの分岐か:
-    # Windowsでは既存の設定値を優先し、他OSでは `code` コマンドでの起動を標準化する。
-    vscode_command = CODE_EXE_PATH if IS_WINDOWS else "code"
+    # OSを問わず設定値（CODE_EXE_PATH）があれば優先し、未設定時のみ `code` にフォールバックする。
+    vscode_command = CODE_EXE_PATH or "code"
     subprocess.Popen([vscode_command, normalized_path])
 
 

--- a/app_runner.py
+++ b/app_runner.py
@@ -12,9 +12,6 @@ from tkinter import font as tkfont
 import subprocess
 import threading
 import yaml
-import win32gui
-import win32con
-import win32api
 import time
 import socket
 import csv
@@ -26,6 +23,13 @@ from PySide6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
 from PySide6.QtCore import Qt, QThread, QTimer
 from PySide6.QtGui import QFont
 import ctypes
+
+IS_WINDOWS = sys.platform == "win32"
+
+if IS_WINDOWS:
+    import win32api
+    import win32con
+    import win32gui
 
 # 定数定義
 TARGET_WINDOW_TITLE = "GUIツールランナー.exe"
@@ -43,6 +47,13 @@ HOSTNAME = socket.gethostname()
 
 # ウインドウを指定のウインドウの内側に移動する関数
 def move_window_inside_relative(target_title, destination_title, padding):
+    """
+    Windows環境でのみ、既存ウィンドウの相対位置を調整する。
+    macOS/Linuxでは何もしない。
+    """
+    if not IS_WINDOWS:
+        return
+
     print("処理を開始します。")
     # 移動先のウインドウの位置とサイズを取得
     hwnd_dest = win32gui.FindWindow(None, destination_title)
@@ -94,7 +105,7 @@ def save_position(root):
     geometry_str = f"{geom.width()}x{geom.height()}+{geom.x()}+{geom.y()}"
     position_data = [HOSTNAME, geometry_str]
     print(f"保存データ: {position_data}")
-    with open(POSITION_FILE, 'w', newline='', encoding="utf_8_sig") as csvfile:
+    with open(POSITION_FILE, 'w', newline='', encoding=ENCODING_FOR_CSV) as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(position_data)
     print("保存完了")
@@ -105,7 +116,7 @@ def restore_position(root):
     """
     print("ウィンドウ位置を復元中...")
     try:
-        with open(POSITION_FILE, newline='', encoding="utf_8_sig") as csvfile:
+        with open(POSITION_FILE, newline='', encoding=ENCODING_FOR_CSV) as csvfile:
             reader = csv.reader(csvfile)
             for row in reader:
                 if row[0] == HOSTNAME:
@@ -151,6 +162,49 @@ def except_processing():
     t, v, tb = sys.exc_info()
     trace = traceback.format_exception(t, v, tb)
     messagebox.showerror("エラーが発生しました", ''.join(trace))
+
+
+def open_folder_in_file_manager(folder_path):
+    """
+    OSごとの標準ファイルマネージャーでフォルダを開く。
+    - Windows: explorer (os.startfile)
+    - macOS: Finder (open)
+    - Linux: xdg-open
+    """
+    if not folder_path:
+        raise ValueError("フォルダパスが指定されていません。")
+
+    normalized_path = os.path.normpath(folder_path)
+    if not os.path.isdir(normalized_path):
+        raise FileNotFoundError(f"フォルダが見つかりません: {normalized_path}")
+
+    if IS_WINDOWS:
+        os.startfile(normalized_path)
+        return
+
+    if sys.platform == "darwin":
+        subprocess.Popen(["open", normalized_path])
+        return
+
+    subprocess.Popen(["xdg-open", normalized_path])
+
+
+def open_folder_in_vscode(folder_path):
+    """
+    VSCode CLI（code）で対象フォルダを開く。
+    固定パス設定が未定義でも、macOS/Linuxで起動できるようにフォールバックする。
+    """
+    if not folder_path:
+        raise ValueError("フォルダパスが指定されていません。")
+
+    normalized_path = os.path.normpath(folder_path)
+    if not os.path.isdir(normalized_path):
+        raise FileNotFoundError(f"フォルダが見つかりません: {normalized_path}")
+
+    # なぜこの分岐か:
+    # Windowsでは既存の設定値を優先し、他OSでは `code` コマンドでの起動を標準化する。
+    vscode_command = CODE_EXE_PATH if IS_WINDOWS else "code"
+    subprocess.Popen([vscode_command, normalized_path])
 
 
 def find_app_python_files(base_folder):
@@ -247,6 +301,8 @@ class App(QMainWindow):
         """
         # アプリのウインドウが作成された後にウインドウ位置を調整
         move_window_inside_relative(TARGET_WINDOW_TITLE, DESTINATION_WINDOW_TITLE, INNER_PADDING)
+        if not IS_WINDOWS:
+            return
         # DESTINATION_WINDOW_TITLE のウィンドウを最前面に表示
         hwnd = win32gui.FindWindow(None, DESTINATION_WINDOW_TITLE)
         if hwnd:
@@ -335,18 +391,26 @@ class App(QMainWindow):
 
     def open_folder(self):
         folder_path = self.folder_path_entry.text()  # フォルダパスを取得
-        if sys.platform == "win32":
-            os.startfile(folder_path)
-        else:
-            subprocess.Popen(["open", folder_path])
+        try:
+            open_folder_in_file_manager(folder_path)
+        except Exception as e:
+            messagebox.showerror("エラー", f"フォルダを開けませんでした: {e}")
 
 
     def open_vscode(self):
         folder_path = self.folder_path_entry.text()
-        # パスを正規化
-        folder_path = os.path.normpath(folder_path)
-        print([CODE_EXE_PATH, folder_path])
-        subprocess.Popen([CODE_EXE_PATH, folder_path])
+        try:
+            open_folder_in_vscode(folder_path)
+        except FileNotFoundError as e:
+            messagebox.showerror("エラー", str(e))
+        except Exception as e:
+            # なぜこのエラー文言か:
+            # macOS/Linuxでは code コマンド未導入が起こりやすく、対処がわかるガイダンスを返す。
+            messagebox.showerror(
+                "エラー",
+                f"VSCodeで開けませんでした: {e}\n"
+                "macOS/Linuxでは、コマンドパレットで 'Shell Command: Install code command in PATH' を実行してください。"
+            )
 
 
     def browse_folder(self):
@@ -701,7 +765,8 @@ def parse_priority(value, fallback=999):
 yaml_settings_path = 'desktop_gui_settings.yaml'
 settings = load_yaml_settings(yaml_settings_path)
 DEFAULT_FOLDER_PATH = settings["app_runner"]["DEFAULT_FOLDER_PATH"]
-CODE_EXE_PATH = settings["app_runner"]["CODE_EXE_PATH"]
+# Windowsでは設定ファイルの固定パスを使い、他OSでは `code` コマンドへフォールバックする。
+CODE_EXE_PATH = settings["app_runner"].get("CODE_EXE_PATH", "code")
 
 # メイン処理
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- macOS環境でも本ツールの開発・起動ができるように、Windows専用の依存で起動失敗しないようにするため。 
- フォルダ表示やVSCode起動など外部連携をOSごとに安全にハンドリングして汎用性を高めるため。 
- ローカル秘匿情報や環境依存ファイルの誤コミットを防ぐために.gitignoreを強化し、READMEを最新の運用手順に合わせるため。 

### Description
- `app_runner.py` に `IS_WINDOWS = sys.platform == "win32"` を追加し、`win32api/win32con/win32gui` の import を Windows 実行時のみに限定しました。 
- ウィンドウ位置調整処理 (`move_window_inside_relative`) と最前面化を Windows 専用処理としてガードし、非Windowsでは早期リターンするように変更しました。 
- OS抽象化関数 `open_folder_in_file_manager()` と `open_folder_in_vscode()` を追加し、フォルダオープンとVSCode起動を OS 別 (`os.startfile` / `open` / `xdg-open`、`code` フォールバック) に統一しました。 
- `open_folder` / `open_vscode` ハンドラを新しい抽象関数経由に差し替え、エラーメッセージに macOS/Linux 向けの対処ガイダンスを追加しました。 
- CSVエンコーディング参照を定数化して読み書きで統一し、README に macOS の開発/起動手順を追記、`.gitignore` を強化しました。 

### Testing
- 構文チェックを `python -m py_compile app_runner.py` で実行し、問題なく成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d26b978db8832c965593b2a9b7b324)